### PR TITLE
feat: support customized tracer

### DIFF
--- a/opentracing.go
+++ b/opentracing.go
@@ -7,21 +7,21 @@ import (
 )
 
 type opentracingPlugin struct {
-	// logResult means log SQL operation result into span log which causes span size grows up.
-	// This is advised to only open in developing environment.
-	logResult bool
+	// opt includes options those opentracingPlugin support.
+	opt *options
 }
 
 // New constructs a new plugin based opentracing. It supports to trace all operations in gorm,
 // so if you have already traced your servers, now this plugin will perfect your tracing job.
 func New(opts ...applyOption) gorm.Plugin {
-	dst := new(options)
+	dst := defaultOption()
 	for _, apply := range opts {
 		apply(dst)
 	}
 
 	return opentracingPlugin{
-		logResult: dst.logResult,
+		//logResult: dst.logResult,
+		opt: dst,
 	}
 }
 

--- a/opentracing_callbacks.go
+++ b/opentracing_callbacks.go
@@ -3,29 +3,29 @@ package gormopentracing
 import "gorm.io/gorm"
 
 func (p opentracingPlugin) beforeCreate(db *gorm.DB) {
-	injectBefore(db, _createOp)
+	p.injectBefore(db, _createOp)
 }
 
 func (p opentracingPlugin) after(db *gorm.DB) {
-	extractAfter(db, p.logResult)
+	p.extractAfter(db, p.opt.logResult)
 }
 
 func (p opentracingPlugin) beforeUpdate(db *gorm.DB) {
-	injectBefore(db, _updateOp)
+	p.injectBefore(db, _updateOp)
 }
 
 func (p opentracingPlugin) beforeQuery(db *gorm.DB) {
-	injectBefore(db, _queryOp)
+	p.injectBefore(db, _queryOp)
 }
 
 func (p opentracingPlugin) beforeDelete(db *gorm.DB) {
-	injectBefore(db, _deleteOp)
+	p.injectBefore(db, _deleteOp)
 }
 
 func (p opentracingPlugin) beforeRow(db *gorm.DB) {
-	injectBefore(db, _rowOp)
+	p.injectBefore(db, _rowOp)
 }
 
 func (p opentracingPlugin) beforeRaw(db *gorm.DB) {
-	injectBefore(db, _rawOp)
+	p.injectBefore(db, _rawOp)
 }

--- a/opentracing_helper.go
+++ b/opentracing_helper.go
@@ -19,7 +19,7 @@ var (
 	// span.Tag keys
 	_tableTagKey = keyWithPrefix("table")
 	// span.Log keys
-	_errorLogKey        = keyWithPrefix("error")
+	//_errorLogKey        = keyWithPrefix("error")
 	_resultLogKey       = keyWithPrefix("result")
 	_sqlLogKey          = keyWithPrefix("sql")
 	_rowsAffectedLogKey = keyWithPrefix("rowsAffected")
@@ -34,7 +34,7 @@ var (
 	json               = jsoniter.ConfigCompatibleWithStandardLibrary
 )
 
-func injectBefore(db *gorm.DB, op operationName) {
+func (p opentracingPlugin) injectBefore(db *gorm.DB, op operationName) {
 	// make sure context could be used
 	if db == nil {
 		return
@@ -45,11 +45,11 @@ func injectBefore(db *gorm.DB, op operationName) {
 		return
 	}
 
-	sp, _ := opentracing.StartSpanFromContext(db.Statement.Context, op.String())
+	sp, _ := opentracing.StartSpanFromContextWithTracer(db.Statement.Context, p.opt.tracer, op.String())
 	db.InstanceSet(opentracingSpanKey, sp)
 }
 
-func extractAfter(db *gorm.DB, verbose bool) {
+func (p opentracingPlugin) extractAfter(db *gorm.DB, verbose bool) {
 	// make sure context could be used
 	if db == nil {
 		return

--- a/options.go
+++ b/options.go
@@ -1,7 +1,21 @@
 package gormopentracing
 
+import "github.com/opentracing/opentracing-go"
+
 type options struct {
+	// logResult means log SQL operation result into span log which causes span size grows up.
+	// This is advised to only open in developing environment.
 	logResult bool
+
+	// tracer allows users to use customized and different tracer to makes tracing clearly.
+	tracer opentracing.Tracer
+}
+
+func defaultOption() *options {
+	return &options{
+		logResult: false,
+		tracer:    opentracing.GlobalTracer(),
+	}
 }
 
 type applyOption func(o *options)
@@ -10,5 +24,16 @@ type applyOption func(o *options)
 func WithLogResult(logResult bool) applyOption {
 	return func(o *options) {
 		o.logResult = logResult
+	}
+}
+
+// WithTracer allows to use customized tracer rather than the global one only.
+func WithTracer(tracer opentracing.Tracer) applyOption {
+	return func(o *options) {
+		if tracer == nil {
+			return
+		}
+
+		o.tracer = tracer
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -3,11 +3,25 @@ package gormopentracing
 import (
 	"testing"
 
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_Option_WithLogResult(t *testing.T) {
 	opt := WithLogResult(true)
 	p := New(opt)
-	assert.Equal(t, true, p.(opentracingPlugin).logResult)
+	assert.Equal(t, true, p.(opentracingPlugin).opt.logResult)
+}
+
+func Test_Option_DefaultOption(t *testing.T) {
+	opt := defaultOption()
+	assert.Equal(t, true, opt.logResult)
+	assert.Equal(t, opentracing.GlobalTracer(), opt.tracer)
+}
+
+func Test_Option_WithTracer_nil(t *testing.T) {
+	opt := defaultOption()
+	WithTracer(nil)(opt)
+	assert.Equal(t, opentracing.GlobalTracer(), opt.tracer)
 }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	github.com/uber/jaeger-lib v2.4.0+incompatible // indirect
-	gorm.io/plugin/opentracing v1.0.0
 	go.uber.org/atomic v1.7.0 // indirect
 	gorm.io/driver/mysql v1.0.4
 	gorm.io/gorm v1.20.12
+	gorm.io/plugin/opentracing v1.0.0
 )
 
 replace gorm.io/plugin/opentracing => ../

--- a/tests/tests_all.sh
+++ b/tests/tests_all.sh
@@ -24,6 +24,9 @@ for dialect in "${dialects[@]}" ; do
       if [ -d tests ]
       then
         cd tests
+        # with customized tracer
+        WITH_TRACER2=true GORM_DIALECT=${dialect} go test -count=1 ./...
+        # with global tracer
         GORM_DIALECT=${dialect} go test -race -count=1 ./...
         cd ..
       fi


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Nonbreaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

* provide the `WithTracer` API to customize tracer
* use `opt options` instead of `logResult` and `tracer` property in `opentracingPlugin`
* define `extractAfter` and `injectBefore` into `opentracingPlugin` methods, and rename `helper.go` as `opentracing_helper.go`


### User Case Description

<!-- Your use case -->

use customized tracer of DB operation rather than have to use global tracer.