### PR TITLE
export applyOptions

### DIFF
--- a/opentracing.go
+++ b/opentracing.go
@@ -13,7 +13,7 @@ type opentracingPlugin struct {
 
 // New constructs a new plugin based opentracing. It supports to trace all operations in gorm,
 // so if you have already traced your servers, now this plugin will perfect your tracing job.
-func New(opts ...applyOption) gorm.Plugin {
+func New(opts ...ApplyOption) gorm.Plugin {
 	dst := defaultOption()
 	for _, apply := range opts {
 		apply(dst)

--- a/options.go
+++ b/options.go
@@ -26,17 +26,17 @@ func defaultOption() *options {
 	}
 }
 
-type applyOption func(o *options)
+type ApplyOption func(o *options)
 
 // WithLogResult enable opentracingPlugin to log the result of each executed sql.
-func WithLogResult(logResult bool) applyOption {
+func WithLogResult(logResult bool) ApplyOption {
 	return func(o *options) {
 		o.logResult = logResult
 	}
 }
 
 // WithTracer allows to use customized tracer rather than the global one only.
-func WithTracer(tracer opentracing.Tracer) applyOption {
+func WithTracer(tracer opentracing.Tracer) ApplyOption {
 	return func(o *options) {
 		if tracer == nil {
 			return
@@ -46,13 +46,13 @@ func WithTracer(tracer opentracing.Tracer) applyOption {
 	}
 }
 
-func WithSqlParameters(logSqlParameters bool) applyOption {
+func WithSqlParameters(logSqlParameters bool) ApplyOption {
 	return func(o *options) {
 		o.logSqlParameters = logSqlParameters
 	}
 }
 
-func WithErrorTagHook(errorTagHook errorTagHook) applyOption {
+func WithErrorTagHook(errorTagHook errorTagHook) ApplyOption {
 	return func(o *options) {
 		if errorTagHook == nil {
 			return


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Exports `applyOptions` for consumption by applications. This is potentially useful for building a conditional/dynamic list of options, without having to call `gormopentracing.New()` in each of the conditionals. For example:

```
if condition {
      gormopentracing.New(
          gormopentracing.WithTracer(tracer),
          gormopentracing.WithSqlParameters(false),
          )
} else
      gormopentracing.New(
          gormopentracing.WithTracer(tracer),
          gormopentracing.WithSqlParameters(true),
          )
}
```
Becomes:
```
if condition {
          applyOpts := []gormopentracing.ApplyOpts {
              gormopentracing.WithTracer(tracer),
              gormopentracing.WithSqlParameters(false),
              // other opts
          }
} else
          applyOpts := []gormopentracing.ApplyOpts {
              gormopentracing.WithTracer(),
              gormopentracing.WithSqlParameters(true),
              // other opts
          }
}
gormopentracing.New(...applyOpts)
```