### PR TITLE
Add operation name options

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
@@ -17,6 +18,7 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/opentracing_callbacks.go
+++ b/opentracing_callbacks.go
@@ -3,7 +3,7 @@ package gormopentracing
 import "gorm.io/gorm"
 
 func (p opentracingPlugin) beforeCreate(db *gorm.DB) {
-	p.injectBefore(db, _createOp)
+	p.injectBefore(db, p.opt.createOpName)
 }
 
 func (p opentracingPlugin) after(db *gorm.DB) {
@@ -11,21 +11,21 @@ func (p opentracingPlugin) after(db *gorm.DB) {
 }
 
 func (p opentracingPlugin) beforeUpdate(db *gorm.DB) {
-	p.injectBefore(db, _updateOp)
+	p.injectBefore(db, p.opt.updateOpName)
 }
 
 func (p opentracingPlugin) beforeQuery(db *gorm.DB) {
-	p.injectBefore(db, _queryOp)
+	p.injectBefore(db, p.opt.queryOpName)
 }
 
 func (p opentracingPlugin) beforeDelete(db *gorm.DB) {
-	p.injectBefore(db, _deleteOp)
+	p.injectBefore(db, p.opt.deleteOpName)
 }
 
 func (p opentracingPlugin) beforeRow(db *gorm.DB) {
-	p.injectBefore(db, _rowOp)
+	p.injectBefore(db, p.opt.rowOpName)
 }
 
 func (p opentracingPlugin) beforeRaw(db *gorm.DB) {
-	p.injectBefore(db, _rawOp)
+	p.injectBefore(db, p.opt.rawOpName)
 }

--- a/options.go
+++ b/options.go
@@ -15,6 +15,24 @@ type options struct {
 
 	// errorTagHook allows users to customized error what kind of error tag should be tagged.
 	errorTagHook errorTagHook
+
+	// createOpName defines operation name for "create" span
+	createOpName operationName
+
+	// updateOpName defines operation name for "update" span
+	updateOpName operationName
+
+	// queryOpName defines operation name for "query" span
+	queryOpName operationName
+
+	// deleteOpName defines operation name for "delete" span
+	deleteOpName operationName
+
+	// rowOpName defines operation name for "row" span
+	rowOpName operationName
+
+	// rawOpName defines operation name for "raw" span
+	rawOpName operationName
 }
 
 func defaultOption() *options {
@@ -23,6 +41,12 @@ func defaultOption() *options {
 		tracer:           opentracing.GlobalTracer(),
 		logSqlParameters: true,
 		errorTagHook:     defaultErrorTagHook,
+		createOpName:     _createOp,
+		updateOpName:     _updateOp,
+		queryOpName:      _queryOp,
+		deleteOpName:     _deleteOp,
+		rowOpName:        _rowOp,
+		rawOpName:        _rawOp,
 	}
 }
 
@@ -59,5 +83,65 @@ func WithErrorTagHook(errorTagHook errorTagHook) ApplyOption {
 		}
 
 		o.errorTagHook = errorTagHook
+	}
+}
+
+func WithCreateOpName(name operationName) ApplyOption {
+	return func(o *options) {
+		if name == "" {
+			return
+		}
+
+		o.createOpName = name
+	}
+}
+
+func WithUpdateOpName(name operationName) ApplyOption {
+	return func(o *options) {
+		if name == "" {
+			return
+		}
+
+		o.updateOpName = name
+	}
+}
+
+func WithQueryOpName(name operationName) ApplyOption {
+	return func(o *options) {
+		if name == "" {
+			return
+		}
+
+		o.queryOpName = name
+	}
+}
+
+func WithDeleteOpName(name operationName) ApplyOption {
+	return func(o *options) {
+		if name == "" {
+			return
+		}
+
+		o.deleteOpName = name
+	}
+}
+
+func WithRowOpName(name operationName) ApplyOption {
+	return func(o *options) {
+		if name == "" {
+			return
+		}
+
+		o.rowOpName = name
+	}
+}
+
+func WithRawOpName(name operationName) ApplyOption {
+	return func(o *options) {
+		if name == "" {
+			return
+		}
+
+		o.rawOpName = name
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -48,3 +48,207 @@ func Test_WithErrorTagHook(t *testing.T) {
 	v2 := reflect.ValueOf(opt.errorTagHook)
 	assert.Equal(t, v1.Pointer(), v2.Pointer())
 }
+
+func Test_Option_WithCreateOpName(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []ApplyOption
+		wantRes operationName
+	}{
+		{
+			name:    "default",
+			wantRes: _createOp,
+		},
+		{
+			name:    "empty",
+			opts:    []ApplyOption{WithCreateOpName("")},
+			wantRes: _createOp,
+		},
+		{
+			name:    "custom",
+			opts:    []ApplyOption{WithCreateOpName("gorm_create")},
+			wantRes: operationName("gorm_create"),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := New(tc.opts...)
+			assert.Equal(t, tc.wantRes, p.(opentracingPlugin).opt.createOpName)
+		})
+	}
+}
+
+func Test_Option_WithUpdateOpName(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []ApplyOption
+		wantRes operationName
+	}{
+		{
+			name:    "default",
+			wantRes: _updateOp,
+		},
+		{
+			name:    "empty",
+			opts:    []ApplyOption{WithUpdateOpName("")},
+			wantRes: _updateOp,
+		},
+		{
+			name:    "custom",
+			opts:    []ApplyOption{WithUpdateOpName("gorm_update")},
+			wantRes: operationName("gorm_update"),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := New(tc.opts...)
+			assert.Equal(t, tc.wantRes, p.(opentracingPlugin).opt.updateOpName)
+		})
+	}
+}
+
+func Test_Option_WithQueryOpName(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []ApplyOption
+		wantRes operationName
+	}{
+		{
+			name:    "default",
+			wantRes: _queryOp,
+		},
+		{
+			name:    "empty",
+			opts:    []ApplyOption{WithQueryOpName("")},
+			wantRes: _queryOp,
+		},
+		{
+			name:    "custom",
+			opts:    []ApplyOption{WithQueryOpName("gorm_query")},
+			wantRes: operationName("gorm_query"),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := New(tc.opts...)
+			assert.Equal(t, tc.wantRes, p.(opentracingPlugin).opt.queryOpName)
+		})
+	}
+}
+
+func Test_Option_WithDeleteOpName(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []ApplyOption
+		wantRes operationName
+	}{
+		{
+			name:    "default",
+			wantRes: _deleteOp,
+		},
+		{
+			name:    "empty",
+			opts:    []ApplyOption{WithDeleteOpName("")},
+			wantRes: _deleteOp,
+		},
+		{
+			name:    "custom",
+			opts:    []ApplyOption{WithDeleteOpName("gorm_delete")},
+			wantRes: operationName("gorm_delete"),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := New(tc.opts...)
+			assert.Equal(t, tc.wantRes, p.(opentracingPlugin).opt.deleteOpName)
+		})
+	}
+}
+
+func Test_Option_WithRowOpName(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []ApplyOption
+		wantRes operationName
+	}{
+		{
+			name:    "default",
+			wantRes: _rowOp,
+		},
+		{
+			name:    "empty",
+			opts:    []ApplyOption{WithRowOpName("")},
+			wantRes: _rowOp,
+		},
+		{
+			name:    "custom",
+			opts:    []ApplyOption{WithRowOpName("gorm_row")},
+			wantRes: operationName("gorm_row"),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := New(tc.opts...)
+			assert.Equal(t, tc.wantRes, p.(opentracingPlugin).opt.rowOpName)
+		})
+	}
+}
+
+func Test_Option_WithRawOpName(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []ApplyOption
+		wantRes operationName
+	}{
+		{
+			name:    "default",
+			wantRes: _rawOp,
+		},
+		{
+			name:    "empty",
+			opts:    []ApplyOption{WithRawOpName("")},
+			wantRes: _rawOp,
+		},
+		{
+			name:    "custom",
+			opts:    []ApplyOption{WithRawOpName("gorm_raw")},
+			wantRes: operationName("gorm_raw"),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := New(tc.opts...)
+			assert.Equal(t, tc.wantRes, p.(opentracingPlugin).opt.rawOpName)
+		})
+	}
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Adds options for operation names:

- `WithCreateOpName`
- `WithUpdateOpName`
- `WithQueryOpName`
- `WithDeleteOpName`
- `WithRowOpName`
- `WithRawOpName`
